### PR TITLE
Iterate over the classifier choices per symbol

### DIFF
--- a/Screenshot-OCR/SLTesseract.h
+++ b/Screenshot-OCR/SLTesseract.h
@@ -18,6 +18,24 @@
 
 
 - (NSString*)recognize:(NSImage*)image;
-- (NSMutableArray*)getIterator:(NSImage*)image;
+
+// returns a 3D NSArray of all possible choices as interpreted by
+// Tesseract per symbol with corresponding confidence intervals (0-1)
+//
+// Example:
+// Assume an image that contains the symbols/characters "A B C"
+// Tesseract would recognize 3 symbols in this image and the following
+// function will return an array that has the all classifier choices
+// per symbol with corresponding confidence intervals
+//
+// Example return value:
+// [[["A",.96],["O",.84],["D",.72]],
+// [["B",.99],["D",.87]],
+// [["O",.92], ["C",.91],["D",.82],["Q",.72],["@",.65]]]
+//
+// Notice on the third symbol ("C"), Tesseract recognizes it as "O"
+// as it has the highest CI but the right answer is "C",
+// which has the next highest CI.
+- (NSArray*)getClassiferChoicesPerSymbol:(NSImage*)image;
 
 @end

--- a/Screenshot-OCR/SLTesseract.h
+++ b/Screenshot-OCR/SLTesseract.h
@@ -18,5 +18,6 @@
 
 
 - (NSString*)recognize:(NSImage*)image;
+- (NSMutableArray*)getIterator:(NSImage*)image;
 
 @end

--- a/Screenshot-OCR/SLTesseract.mm
+++ b/Screenshot-OCR/SLTesseract.mm
@@ -90,7 +90,7 @@
 }
 
 - (NSMutableArray*)getIterator:(NSImage*)image {
-    // returns a 2D array of all possible choices as interpreted by
+    // returns a 3D array of all possible choices as interpreted by
     // Tesseract with corresponding confidence intervals
     
     // initialize the tesseract
@@ -120,23 +120,27 @@
     // Iterator `level` - can be block, paragraph, textline, or symbol
     tesseract::PageIteratorLevel level = tesseract::RIL_SYMBOL;
     
-    // Holds array of possible choices with corresponding CI
+    // Holds array of array of symbols where each symbol has all
+    // possible classifier choices with corresponding CI
     NSMutableArray *result = [NSMutableArray array];
     if(ri != 0) {
+        // Holds current array for current symbol and its classifier choices
+        NSMutableArray *symbol_result = [NSMutableArray array];
         do {
             const char* symbol = ri->GetUTF8Text(level);
             if(symbol != 0) {
                 // Iterate through all classifer choices for symbol
                 tesseract::ChoiceIterator ci(*ri);
                 do {
-                    // Array to hold current character + CI in iterator
+                    // Array to hold current symbol + CI in iterator
                     NSMutableArray *character = [NSMutableArray array];
                     const char* choice = ci.GetUTF8Text();
                     [character addObject:@(choice)];
                     [character addObject:@(ci.Confidence())];
-                    [result addObject:character];
+                    [symbol_result addObject:character];
                 } while(ci.Next());
             }
+            [result addObject:symbol_result];
             delete[] symbol;
         } while((ri->Next(level)));
     }

--- a/Screenshot-OCR/SLTesseract.mm
+++ b/Screenshot-OCR/SLTesseract.mm
@@ -89,9 +89,10 @@
     return text;
 }
 
-- (NSMutableArray*)getIterator:(NSImage*)image {
+- (NSArray*)getClassiferChoicesPerSymbol:(NSImage*)image {
     // returns a 3D array of all possible choices as interpreted by
-    // Tesseract with corresponding confidence intervals
+    // Tesseract per symbol/character with corresponding confidence
+    // intervals (0-1)
     
     // initialize the tesseract
     _tesseract->Init(_absoluteDataPath.fileSystemRepresentation, self.language.UTF8String);
@@ -105,7 +106,6 @@
     
     // set the image
     [self setEngineImage:image];
-    [self saveThresholdedImage];
     
     int returnCode = 0;
     // call the recognize function
@@ -117,7 +117,7 @@
     // Result iterator object to be iterated through
     tesseract::ResultIterator* ri = _tesseract->GetIterator();
     
-    // Iterator `level` - can be block, paragraph, textline, or symbol
+    // Iterator `level`, will go through each recognized symbol
     tesseract::PageIteratorLevel level = tesseract::RIL_SYMBOL;
     
     // Holds array of array of symbols where each symbol has all
@@ -136,7 +136,7 @@
                     NSMutableArray *character = [NSMutableArray array];
                     const char* choice = ci.GetUTF8Text();
                     [character addObject:@(choice)];
-                    [character addObject:@(ci.Confidence())];
+                    [character addObject:@(ci.Confidence()/100)];
                     [symbol_result addObject:character];
                 } while(ci.Next());
             }
@@ -144,7 +144,8 @@
             delete[] symbol;
         } while((ri->Next(level)));
     }
-    return result;
+    NSArray *resultFinal = [result copy];
+    return resultFinal;
 }
 
 

--- a/Screenshot-OCR/SLTesseract.mm
+++ b/Screenshot-OCR/SLTesseract.mm
@@ -90,6 +90,9 @@
 }
 
 - (NSMutableArray*)getIterator:(NSImage*)image {
+    // returns a 2D array of all possible choices as interpreted by
+    // Tesseract with corresponding confidence intervals
+    
     // initialize the tesseract
     _tesseract->Init(_absoluteDataPath.fileSystemRepresentation, self.language.UTF8String);
     
@@ -111,15 +114,22 @@
     
     if(returnCode != 0) printf("recognition function failed\n");
     
+    // Result iterator object to be iterated through
     tesseract::ResultIterator* ri = _tesseract->GetIterator();
+    
+    // Iterator `level` - can be block, paragraph, textline, or symbol
     tesseract::PageIteratorLevel level = tesseract::RIL_SYMBOL;
+    
+    // Holds array of possible choices with corresponding CI
     NSMutableArray *result = [NSMutableArray array];
     if(ri != 0) {
         do {
             const char* symbol = ri->GetUTF8Text(level);
             if(symbol != 0) {
+                // Iterate through all classifer choices for symbol
                 tesseract::ChoiceIterator ci(*ri);
                 do {
+                    // Array to hold current character + CI in iterator
                     NSMutableArray *character = [NSMutableArray array];
                     const char* choice = ci.GetUTF8Text();
                     [character addObject:@(choice)];


### PR DESCRIPTION
I added a function that shows how the iterator would be implemented. It starts from line 117 because it shares code from the `recognize` function. It is not "complete" but it is in a workable state and represents how I approached it.

The way the function works is it gets an image, Tesseract extracts all the symbols from the image and for each symbol, the function gets all possible classifier choices for each symbol with CI. This results in a 3D array: an array of array of symbols where each symbol has an array of possible classifier choices + CI.

I am looking for any feedback on whether you think this is how the function should be implemented.

There are a few things to keep in mind. This implementation is "symbol"-specific (aka character-based) and based on the API, while the "PageIteratorLevel" can be symbol, line, paragraph or block, the use of the ChoiceIterator in line 133 below is symbol-only. That means Tesseract won't give confidence intervals for an entire line, which is understandable.

I don't think it make sense to have a ChoiceIterator and a 3D array for any other level other than symbol. If there are multiple symbols in a picture, then yes, you would want to get each symbol that Tesseract recognizes and get all classifier choices for each symbol, hence the 3D array.

It might be worthwhile to support for the PageIteratorLevels as a separate function from the symbol-specific implementation.

What are your thoughts?